### PR TITLE
Make map background transparent

### DIFF
--- a/MMM-RAIN-MAP.css
+++ b/MMM-RAIN-MAP.css
@@ -44,3 +44,7 @@
 .rain-map-time.rain-map-forecast {
   color: var(--color-forecast);
 }
+
+.leaflet-container {
+  background-color: transparent !important;
+}


### PR DESCRIPTION
Leaflet uses a gray background as default, which you can see when the tiles load slowly. With this change we set the background to transparent, so slow loading is less noticeable (especially on a black/dark background).

This should fix #37.